### PR TITLE
Created FillingModifierSystem

### DIFF
--- a/src/main/java/org/terasology/edibleFlora/system/FillingModifierSystem.java
+++ b/src/main/java/org/terasology/edibleFlora/system/FillingModifierSystem.java
@@ -1,0 +1,25 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.edibleFlora.system;
+
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.hunger.component.FoodComponent;
+import org.terasology.simpleFarming.events.ModifyFilling;
+import org.terasology.utilities.modifiable.ModifiableValue;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class FillingModifierSystem extends BaseComponentSystem {
+
+    @ReceiveEvent
+    public void onFillingModifiedEvent(ModifyFilling event, EntityRef entity) {
+        FoodComponent foodComponent = new FoodComponent();
+        foodComponent.filling = new ModifiableValue(event.getNewFilling());
+        entity.addOrSaveComponent(foodComponent);
+    }
+}

--- a/src/main/java/org/terasology/edibleFlora/system/FillingModifierSystem.java
+++ b/src/main/java/org/terasology/edibleFlora/system/FillingModifierSystem.java
@@ -11,15 +11,16 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.hunger.component.FoodComponent;
 import org.terasology.simpleFarming.events.ModifyFilling;
-import org.terasology.utilities.modifiable.ModifiableValue;
 
+/**
+ * This system is used to return any modified value of the FoodComponent of a seed
+ * Can be used with any modifiers for seeds
+ */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class FillingModifierSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onFillingModifiedEvent(ModifyFilling event, EntityRef entity) {
-        FoodComponent foodComponent = new FoodComponent();
-        foodComponent.filling = new ModifiableValue(event.getNewFilling());
-        entity.addOrSaveComponent(foodComponent);
+        entity.getComponent(FoodComponent.class).filling.preAdd(event.getNewFilling());
     }
 }


### PR DESCRIPTION
### Contains
The Filling Modifier System is a system that deals with the modifications in filling of the seeds by handling the OnFillingModifiedEvent handler. This is used currently in synergy with https://github.com/Terasology/SimpleFarming/pull/94 to modify the filling trait of the seeds via its Genes.

Also includes remaining recipes for the SeedWorkstation to allow breeding of like seeds

### How to test :
- Use the console command to get a seed, for example : `give apple`
- Plant the seed on the ground to get a bush
- Once the bush is fully grown, harvest it. This will attach genes to the seed and modify its filling value.
- Use the `setHunger <value>` command to set your hunger to a measurable value, say 50
- Eat the seed by right clicking while holding it and not looking at a block
- Use the `showHunger` command to see your hunger value. The value can be tallied with the difference between the setHunger and current hunger and the Genes observed via the `heldGenomeCheck` command.

**Note** : Make sure https://github.com/Terasology/SimpleFarming/pull/94 is a part of your workspace to test this properly.

### To-do
- [x] Javadoc
- [ ] Add remaining recipes